### PR TITLE
Use optionator for cli arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # eslint-nibble Changelog
 
 ### MASTER
+- (Breaking) Use optionator for parsing cli arguments.  Stop defaulting to `cwd`
 
 ### 0.1.1
 - (Fix) Remove require for babel polyfill

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "eslint-friendly-formatter": "^1.0.8",
     "eslint-stats": "^0.1.3",
     "eslint-summary": "^1.0.0",
-    "inquirer": "^0.8.5"
+    "inquirer": "^0.8.5",
+    "optionator": "^0.6.0"
   },
   "devDependencies": {
     "babel": "^5.6.14",

--- a/src/config/options.js
+++ b/src/config/options.js
@@ -1,0 +1,33 @@
+/**
+ * @fileoverview Options configuration for optionator.
+ * @author Ian VanSchooten
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+import optionator from 'optionator';
+
+//------------------------------------------------------------------------------
+// Initialization and Public Interface
+//------------------------------------------------------------------------------
+
+
+export default optionator({
+  prepend: 'usage: eslint-nibble [file.js] [dir]',
+  options: [{
+    heading: 'Options'
+  }, {
+    option: 'help',
+    alias: 'h',
+    type: 'Boolean',
+    description: 'Show help'
+  }, {
+    option: "version",
+    alias: "v",
+    type: "Boolean",
+    description: "Outputs the version number"
+  }]
+})

--- a/src/main.js
+++ b/src/main.js
@@ -2,52 +2,72 @@ import { CLIEngine } from 'eslint';
 import chalk from 'chalk';
 import inquirer from 'inquirer';
 import * as fmt from './config/formatters';
+import options from './config/options';
+import { version } from '../package.json';
 
-var formatter;
-
+let currentOptions;
+let files;
+let formatter;
 let cli = new CLIEngine({});
-let args = (process.argv.slice(2).length > 0) ? process.argv.slice(2) : ['.'];
-let report = cli.executeOnFiles(args);
 
-if (report && (report.errorCount > 0 || report.warningCount > 0)) {
-  // todo: break this into seperate module
-  // If something is totally broken, should be able to tell from first message
-  let firstMsg = report.results[0].messages[0];
-  if (firstMsg && firstMsg.fatal) {
-    console.log(chalk.red(firstMsg.message));
-  } else {
-    // Display stats by rule
-    formatter = cli.getFormatter(fmt.stats);
-    console.log(formatter(report.results));
-    // Display summary
-    formatter = cli.getFormatter(fmt.summary);
-    console.log(formatter(report.results));
+// For now, default behavior doesn't work
+try {
+  currentOptions = options.parse(process.argv);
+} catch (error) {
+  console.error(error.message);
+  process.exit(1);
+}
 
-    inquirer.prompt([{
-      name: 'rule',
-      type: 'input',
-      message: 'Type in the rule you want to focus on'
-    }], function gotInput(answers) {
-      // todo: create another module here
-      let filteredResults = report.results.map(function (result) {
-        let filteredMessages = result.messages.filter(function (msg) {
-          return (msg.ruleId === answers.rule);
-        });
-        if (filteredMessages) {
-          return {
-            filePath: result.filePath,
-            messages: filteredMessages,
-            errorCount: filteredMessages.length,
-            warningCount: result.warningCount
-          }
-        };
-      });
-      // Display detailed error reports
-      formatter = cli.getFormatter(fmt.detailed);
-      console.log(formatter(filteredResults));
-    });
-  }
+files = currentOptions._;
+
+if (currentOptions.version) { // version from package.json
+  console.log("v" + version);
+} else if (currentOptions.help || (!files.length)) {
+  console.log(options.generateHelp());
 } else {
-  console.log(chalk.green('Great job, all lint rules passed.'));
+
+  let report = cli.executeOnFiles(files);
+
+  if (report && (report.errorCount > 0 || report.warningCount > 0)) {
+    // todo: break this into seperate module
+    // If something is totally broken, should be able to tell from first message
+    let firstMsg = report.results[0].messages[0];
+    if (firstMsg && firstMsg.fatal) {
+      console.log(chalk.red(firstMsg.message));
+    } else {
+      // Display stats by rule
+      formatter = cli.getFormatter(fmt.stats);
+      console.log(formatter(report.results));
+      // Display summary
+      formatter = cli.getFormatter(fmt.summary);
+      console.log(formatter(report.results));
+
+      inquirer.prompt([{
+        name: 'rule',
+        type: 'input',
+        message: 'Type in the rule you want to focus on'
+      }], function gotInput(answers) {
+        // todo: create another module here
+        let filteredResults = report.results.map(function (result) {
+          let filteredMessages = result.messages.filter(function (msg) {
+            return (msg.ruleId === answers.rule);
+          });
+          if (filteredMessages) {
+            return {
+              filePath: result.filePath,
+              messages: filteredMessages,
+              errorCount: filteredMessages.length,
+              warningCount: result.warningCount
+            }
+          };
+        });
+        // Display detailed error reports
+        formatter = cli.getFormatter(fmt.detailed);
+        console.log(formatter(filteredResults));
+      });
+    }
+  } else {
+    console.log(chalk.green('Great job, all lint rules passed.'));
+  }
 }
 


### PR DESCRIPTION
This will allow greater flexibility in the future if named arguments are added, perhaps to pass along to ESLint for instance.

However, the current default behavior of executing against `cwd` will be broken.  And actually, I think it's better to not have such a default.  Instead, the help screen is displayed if no arguments are given.