### PR TITLE
Use require.resolve to support cases when when formatters installed on the same level as eslint-nibbler

### DIFF
--- a/src/config/formatters.js
+++ b/src/config/formatters.js
@@ -2,8 +2,6 @@
 These will be used as custom formatters.
  */
 
-import path from 'path';
-
-export var stats = path.resolve(__dirname + '/../../node_modules/eslint-stats/byErrorAndWarning.js');
-export var summary = path.resolve(__dirname + '/../../node_modules/eslint-summary/summary.js');
-export var detailed = path.resolve(__dirname + '/../../node_modules/eslint-friendly-formatter/index.js');
+export var stats = require.resolve('eslint-stats/byErrorAndWarning.js');
+export var summary = require.resolve('eslint-summary/summary.js');
+export var detailed = require.resolve('eslint-friendly-formatter');


### PR DESCRIPTION
E.g. npm dedupe or npm@3 or just direct formatter usage in the linted module.