### PR TITLE
Update Travis to supported versions of node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-    - "0.10"
-    - "0.12"
-    - "stable"
+    - "4"
+    - "5"
+    - "6"
 sudo: false


### PR DESCRIPTION
Dropping CI for very old versions of node.js, in preparation for upgrade to ESLint 3.0