### PR TITLE
Add support for —ext to set file extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Add something like the following to your `package.json` file:
 }
 ```
 
-This will run eslint against javascript files in the `lib/` and `tests/` directories, as well as `index.js`.
+This will run eslint against .js files in the `lib/` and `tests/` directories, as well as `index.js`.
 
 Then, to run eslint-nibble, you can use:
 
@@ -43,6 +43,27 @@ Eslint-nibble will then display a rundown of the rules that are failing and a su
 Type in the name of the rule, and then a detailed list of the errors will be presented, using [eslint-friendly-formatter](https://github.com/royriojas/eslint-friendly-formatter).  If you are using iTerm2 or Guake, you can set them up so that your text editor opens to the correct line when you click on the filename.
 
 ![eslint-friendly-formatter-screenshot](docs/eslint-friendly-formatter-screenshot.png)
+
+## Options
+
+### --ext
+
+If your javascript files have an extension other than `.js`, you can use the `--ext` flag to
+specify which extensions to examine.  For example, this will check all files ending in ``.jsx` or ``.js`:
+
+```shell
+eslint-nibble --ext .jsx,.js lib/
+```
+
+### globs
+
+You are not limited to directory and file names as arguments, you can also specify a glob pattern.
+For example, to examine all .jsx files in "test/" directories within "lib/":
+
+```shell
+eslint-nibble lib/**/test/**/*.jsx
+```
+
 
 ## Notes
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -11,12 +11,14 @@ let cli = {
 
   execute: function (args) {
     let currentOptions,
-        files;
+        files,
+        extensions;
 
     // Parse options
     try {
       currentOptions = options.parse(args);
       files = currentOptions._;
+      extensions = currentOptions.ext;
     } catch (error) {
       console.error(error.message);
       return 1;
@@ -30,6 +32,7 @@ let cli = {
       // Show help
       console.log(options.generateHelp());
     } else {
+      nibbler.setExtensions(extensions);
       let report = nibbler.nibbleOnFiles(files);
       if (report && (report.errorCount > 0 || report.warningCount > 0)) {
         // Check if there was a fatal error

--- a/src/config/options.js
+++ b/src/config/options.js
@@ -29,5 +29,10 @@ export default optionator({
     alias      : 'v',
     type       : 'Boolean',
     description: 'Outputs the version number'
+  }, {
+    option     : 'ext',
+    type       : '[String]',
+    default    : '.js',
+    description: 'Specify JavaScript file extensions'
   }]
 });

--- a/src/nibbler.js
+++ b/src/nibbler.js
@@ -59,6 +59,10 @@ function filterResults(report, msgKey, options) {
 
 module.exports = {
 
+  setExtensions(ext) {
+    cli = new CLIEngine({extensions: ext});
+  },
+
   nibbleOnFiles(files) {
     let report = cli.executeOnFiles(files);
     return report;

--- a/tests/fixtures/files/jsx/.eslintrc
+++ b/tests/fixtures/files/jsx/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "semi": [2, "always"]
+  }
+}

--- a/tests/fixtures/files/jsx/no-semi.jsx
+++ b/tests/fixtures/files/jsx/no-semi.jsx
@@ -1,0 +1,2 @@
+var foo = 1
+foo++;

--- a/tests/lib/nibbler-test.js
+++ b/tests/lib/nibbler-test.js
@@ -194,3 +194,24 @@ test('getFormattedResults :: Returns formatted report for built-in formatter', f
   t.ok(formattedResult, 'returns result');
   t.equal(formattedResult, expectedResult, 'used the correct formatter');
 });
+
+test('nibbler :: Examines files with provided extensions', function (t) {
+  t.plan(3);
+  var files = path.resolve(path.join(__dirname, '/../fixtures/files/jsx/'));
+  nibbler.setExtensions(['.jsx']);
+  var report = nibbler.nibbleOnFiles([files]);
+  t.ok(report, 'returns report');
+  t.ok(report.errorCount, 'report has an errorCount');
+  t.equal(report.errorCount, 1, 'report errorCount is 1');
+});
+
+test('nibbler :: Allows multiple extensions', function (t) {
+  t.plan(3);
+  var jsxFiles = path.resolve(path.join(__dirname, '/../fixtures/files/jsx/'));
+  var jsFiles = path.resolve(path.join(__dirname, '/../fixtures/files/semi-error/'));
+  nibbler.setExtensions(['.jsx', '.js']);
+  var report = nibbler.nibbleOnFiles([jsxFiles, jsFiles]);
+  t.ok(report, 'returns report');
+  t.ok(report.errorCount, 'report has an errorCount');
+  t.equal(report.errorCount, 2, 'report errorCount is 2');
+});


### PR DESCRIPTION
Fixes #21

This adds support for a `--ext` cli option, matching that of ESLint itself, which will allow files with extensions other than `.js` to be examined. 