### PR TITLE
Upgrade dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # eslint-nibble Changelog
 
 ### MASTER
+- (Breaking) Update to ESLint ^3.0.0
+- (Dep) Bump versions of inquirer & eslint-friendly-formatter
 
 ### 2.1.0
 - (Enhance)  Add `--ext` option

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
   },
   "dependencies": {
     "chalk": "^1.0.0",
-    "eslint-friendly-formatter": "^1.0.8",
     "eslint": "^3.0.0",
+    "eslint-friendly-formatter": "^2.0.6",
     "eslint-stats": "^0.1.3",
     "eslint-summary": "^1.0.0",
     "inquirer": "^0.12.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "eslint-friendly-formatter": "^2.0.6",
     "eslint-stats": "^0.1.3",
     "eslint-summary": "^1.0.0",
-    "inquirer": "^0.12.0",
+    "inquirer": "^1.1.2",
     "optionator": "^0.8.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
   },
   "dependencies": {
     "chalk": "^1.0.0",
-    "eslint": "^2.0.0",
     "eslint-friendly-formatter": "^1.0.8",
+    "eslint": "^3.0.0",
     "eslint-stats": "^0.1.3",
     "eslint-summary": "^1.0.0",
     "inquirer": "^0.12.0",

--- a/src/cli.js
+++ b/src/cli.js
@@ -56,13 +56,14 @@ let cli = {
           name   : 'rule',
           type   : 'input',
           message: 'Type in the rule you want to focus on'
-        }], function gotInput(answers) {
-          // Display detailed error reports
-          let ruleName = answers.rule;
-          let ruleResults = nibbler.getRuleResults(report, ruleName);
-          let detailed = nibbler.getFormattedResults(ruleResults, fmt.detailed);
-          console.log(detailed);
-        });
+        }])
+          .then(function gotInput(answers) {
+            // Display detailed error reports
+            let ruleName = answers.rule;
+            let ruleResults = nibbler.getRuleResults(report, ruleName);
+            let detailed = nibbler.getFormattedResults(ruleResults, fmt.detailed);
+            console.log(detailed);
+          });
       // No report or not any errors or warnings
       } else {
         console.log(chalk.green('Great job, all lint rules passed.'));

--- a/tests/fixtures/files/jsx/.eslintrc
+++ b/tests/fixtures/files/jsx/.eslintrc
@@ -1,4 +1,5 @@
 {
+  "root": true,
   "rules": {
     "semi": [2, "always"]
   }

--- a/tests/fixtures/files/semi-error/.eslintrc
+++ b/tests/fixtures/files/semi-error/.eslintrc
@@ -1,4 +1,5 @@
 {
+  "root": true,
   "rules": {
     "semi": [2, "always"]
   }

--- a/tests/fixtures/files/semi-okay/.eslintrc
+++ b/tests/fixtures/files/semi-okay/.eslintrc
@@ -1,4 +1,5 @@
 {
+  "root": true,
   "rules": {
     "semi": [2, "always"]
   }

--- a/tests/fixtures/files/semi-warn/.eslintrc
+++ b/tests/fixtures/files/semi-warn/.eslintrc
@@ -1,4 +1,5 @@
 {
+  "root": true,
   "rules": {
     "semi": [1, "always"]
   }


### PR DESCRIPTION
This upgrades several dependencies to their latest versions:

- eslint: `^3.0.0`
- eslint-friendly-formatter: `^2.0.6`
- inquirer: `^1.1.2`

The change to eslint-friendly-formatter will cause a summary of the files to be printed at the end of the report, giving nice, clickable links to each file with errors, in addition to the more detailed errors above.

The changes to inquirer don't seem to have had any effect on the end-user experience of eslint-nibble

The changes to ESLint are technically non-breaking for this tool, but I'm keeping in lock-step with major versions of ESLint, so this will require a major version bump.

Supersedes #22 