### PR TITLE
Allow arrowing through results

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -1,0 +1,2 @@
+[*.js]
+indent_size = 2;

--- a/src/trim-stat.js
+++ b/src/trim-stat.js
@@ -1,0 +1,17 @@
+
+/**
+ * Trim out whitespace from a stat while preserving ansi escape codes
+ *
+ * @param  {string} stat   The stat to trim
+ * @param  {number} maxLen The maximum allowable length of the stat
+ * @return {string}        The trimmed stat
+ */
+function trimStat(stat, maxLen) {
+  if (stat.length <= maxLen) return stat;
+
+  const diffFromMax = stat.length - maxLen;
+  const ansiEscape = stat.slice(stat.length - 10);
+  return stat.slice(0, stat.length - diffFromMax - 10) + ansiEscape;
+}
+
+module.exports = trimStat;

--- a/tests/lib/trim-stat-test.js
+++ b/tests/lib/trim-stat-test.js
@@ -1,0 +1,36 @@
+'use strict';
+
+var test = require('tape-catch');
+var trimStat = require('../../lib/trim-stat');
+
+test('trimStat()', function (outer) {
+  outer.test('trims three characters of whitespace when length is three greater than max', function (t) {
+    t.plan(1);
+    const stat = 'semi:  \u001b[35m  8\u001b[39m|\u001b[41m               \u001b[49m';
+    const expected = 'semi:  \u001b[35m  8\u001b[39m|\u001b[41m            \u001b[49m';
+    const result = trimStat(stat, stat.length - 3);
+    t.equal(result, expected, 'three spaces trimmed');
+  });
+
+  outer.test('trims one character of whitespace when length is one greater than max', function (t) {
+    t.plan(1);
+    const stat = 'semi:  \u001b[35m  8\u001b[39m|\u001b[41m               \u001b[49m';
+    const expected = 'semi:  \u001b[35m  8\u001b[39m|\u001b[41m              \u001b[49m';
+    const result = trimStat(stat, stat.length - 1);
+    t.equal(result, expected, 'one space trimmed');
+  });
+
+  outer.test('returns original string if length is equal to max', function (t) {
+    t.plan(1);
+    const stat = 'semi:  \u001b[35m  8\u001b[39m|\u001b[41m               \u001b[49m';
+    const result = trimStat(stat, stat.length);
+    t.equal(result, stat, 'original string returned');
+  });
+
+  outer.test('returns original string if length is less than max', function (t) {
+    t.plan(1);
+    const stat = 'semi:  \u001b[35m  8\u001b[39m|\u001b[41m               \u001b[49m';
+    const result = trimStat(stat, stat.length + 1);
+    t.equal(result, stat, 'original string returned');
+  });
+});


### PR DESCRIPTION
This closes #2.

This change splits up the stats that are returned from the eslint-stats formatter, and uses them as an array of choices that the user can  arrow up/down and select, instead of typing in the rule name.