### PR TITLE
Use `resolve` library to allow install-less npx

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3024,8 +3024,7 @@
     "path-parse": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
-      "dev": true
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
     },
     "path-type": {
       "version": "2.0.0",
@@ -3336,10 +3335,9 @@
       }
     },
     "resolve": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
-      "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
-      "dev": true,
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+      "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
       "requires": {
         "path-parse": "^1.0.5"
       }
@@ -3695,6 +3693,15 @@
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
+        },
+        "resolve": {
+          "version": "1.7.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
+          "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.5"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "eslint-stats": "ianvs/eslint-stats#cb1ff8251b50c7f0cb431a2b395431ebfdeb10c8",
     "eslint-summary": "^1.0.0",
     "inquirer": "^6.2.0",
-    "optionator": "^0.8.2"
+    "optionator": "^0.8.2",
+    "resolve": "^1.8.1"
   },
   "devDependencies": {
     "babel-cli": "^6.23.0",

--- a/src/config/formatters.js
+++ b/src/config/formatters.js
@@ -2,6 +2,8 @@
 These will be used as custom formatters.
  */
 
-export var stats = require.resolve('eslint-stats/byErrorAndWarning.js');
-export var summary = require.resolve('eslint-summary/summary.js');
-export var detailed = require.resolve('eslint-formatter-friendly');
+import resolve from 'resolve';
+
+export var stats = resolve.sync('eslint-stats/byErrorAndWarning.js', { cwd: process.cwd() });
+export var summary = resolve.sync('eslint-summary/summary.js', { cwd: process.cwd() });
+export var detailed = resolve.sync('eslint-formatter-friendly', { cwd: process.cwd() });

--- a/src/nibbler.js
+++ b/src/nibbler.js
@@ -1,6 +1,8 @@
 'use strict';
 
-import { CLIEngine } from 'eslint';
+import resolve from 'resolve';
+
+const { CLIEngine } = require(resolve.sync('eslint', { cwd: process.cwd() }));
 let cli = new CLIEngine({});
 
 function getCounts(messages) {


### PR DESCRIPTION
Fixes #45 

This should theoretically allow `eslint-nibble` to be run with the `npx`
command without actually being installed on the users filesystem.

@ljharb, is this the correct way to use `resolve`?  I'm not really sure what's the best way to test/check this, either.