### PR TITLE
Respect `--rules` in `--no-interactive`

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -110,8 +110,11 @@ const cli = {
         }
 
         if (!isInteractive) {
+          const finalReport = allowedRules
+            ? nibbler.getRuleResults(report, allowedRules)
+            : report;
           // Just give an exit code based on having any errors, no interactive menu
-          const output = nibbler.getFormattedResults(report, format);
+          const output = nibbler.getFormattedResults(finalReport, format);
           console.log(output);
 
           return report.errorCount > 0 ? 1 : 0;

--- a/src/nibbler.js
+++ b/src/nibbler.js
@@ -44,6 +44,12 @@ function filterResults(report, msgKey, options) {
       if (options.compareVal) {
         return (msg[msgKey] === options.compareVal);
       }
+      if (options.includes) {
+        if (!Array.isArray(options.includes)) {
+          throw new Error('filterResults: `options.includes` must be an array');
+        }
+        return options.includes.includes(msg[msgKey]);
+      }
       return false;
     });
     if (filteredMessages) {
@@ -97,7 +103,9 @@ module.exports = {
   },
 
   getRuleResults(report, ruleName) {
-    const ruleResults = filterResults(report, 'ruleId', { compareVal: ruleName });
+    const ruleResults = Array.isArray(ruleName)
+      ? filterResults(report, 'ruleId', { includes: ruleName })
+      : filterResults(report, 'ruleId', { compareVal: ruleName });
     return ruleResults;
   },
 

--- a/tests/fixtures/files/multi-error/.eslintrc
+++ b/tests/fixtures/files/multi-error/.eslintrc
@@ -1,0 +1,7 @@
+{
+  "root": true,
+  "rules": {
+    "semi": [2, "always"],
+    "no-plusplus": 2
+  }
+}

--- a/tests/fixtures/files/multi-error/no-semi-plusplus.js
+++ b/tests/fixtures/files/multi-error/no-semi-plusplus.js
@@ -1,0 +1,2 @@
+var foo = 1
+foo++;

--- a/tests/lib/nibbler-test.js
+++ b/tests/lib/nibbler-test.js
@@ -159,6 +159,19 @@ test('getRuleResults :: Returns correct number of fixable errors and warnings', 
   });
 });
 
+test('getRuleResults :: allows more than one rule', function (t) {
+  t.plan(5);
+  var report = require('../fixtures/reports/one-file-two-errors-no-warnings-two-rules');
+  var ruleName1 = report.results[0].messages[0].ruleId;
+  var ruleName2 = report.results[0].messages[1].ruleId;
+  t.notEqual(ruleName1, ruleName2);
+  var ruleReport = nibbler.getRuleResults(report, [ruleName1, ruleName2]);
+  t.equal(ruleReport.results[0].errorCount, 2, '2 errors in file');
+  t.equal(ruleReport.results[0].warningCount, 0, '0 warnings in file');
+  t.equal(ruleReport.errorCount, 2, '2 error total');
+  t.equal(ruleReport.warningCount, 0, '0 warnings total');
+});
+
 test('getFatalResults :: Returns fatal error report', function (t) {
   t.plan(12);
   var report = require('../fixtures/reports/one-file-one-fatal-error');


### PR DESCRIPTION
Fixes #67.

Turns out we weren't filtering based on provided `--rules` when running in `--no-interactive`, which kind of defeated the whole purpose.