### PR TITLE
Add `--multi` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ When used in conjunction with the `--cache` flag, controls where the ESLint cach
 is written.  See the [ESLint docs](https://eslint.org/docs/user-guide/command-line-interface#--cache-location)
 for more details.
 
+### `--multi`
+Allows selection of more than one rule at a time in the interactive cli.
+
 ### `--no-warnings`
 Only show results for linting errors, not warnings.
 

--- a/src/config/options.js
+++ b/src/config/options.js
@@ -59,6 +59,11 @@ export default optionator({
     default    : 'true',
     description: 'Include warning results'
   }, {
+    option     : 'multi',
+    type       : 'Boolean',
+    default    : 'false',
+    description: 'Allow fixing multiple rules at one time'
+  }, {
     option     : 'interactive',
     type       : 'Boolean',
     default    : 'true',


### PR DESCRIPTION
Fixes #46 

This adds a new `--multi` rule, which will enable checkboxes in the interactive ui so that more than one rule can be selected at one time, for example, to autofix all whitespace failures in one go. 

![image](https://user-images.githubusercontent.com/4616705/89110278-3793f080-d417-11ea-8128-7d8e311850a2.png)

![image](https://user-images.githubusercontent.com/4616705/89110286-49759380-d417-11ea-8080-7c325f5beffc.png)

![image](https://user-images.githubusercontent.com/4616705/89110296-5db99080-d417-11ea-9e24-078cb30b880c.png)
 