### PR TITLE
Add --rulesdir option

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ If you have so many failing rules that navigating the list is cumbersome, use th
 the rules that are displayed.  Multiple rules can be included as comma-separated strings (e.g. `--rule semi,quotes`),
 or by using multiple `--rule` flags (e.g. `--rule semi --rule quotes`).
 
+### `--rulesdir`
+This corresponds to the eslint `--rulesdir` [option](https://eslint.org/docs/user-guide/command-line-interface#-rulesdir).  Use it to specify a path to custom eslint rules.
+
 ### `--no-interactive`
 Potentially useful in CI, or any other situation where you would like to run ESLint using your standard project config (`.eslintrc`), but only on a subset of rules (using the `--rule` flag).  Using `--no-interactive` will prevent eslint-nibble from displaying a menu, but will instead print out any warnings/errors and return an exit code of 1 if there are errors, or 0 otherwise, just like ESLint itself does.
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -18,6 +18,7 @@ const cli = {
         cache,
         cacheLocation,
         allowedRules,
+        rulesDir,
         includeWarnings,
         isInteractive,
         isMulti,
@@ -32,6 +33,7 @@ const cli = {
       cache = currentOptions.cache;
       cacheLocation = currentOptions.cacheLocation;
       allowedRules = currentOptions.rule;
+      rulesDir = currentOptions.rulesdir;
       includeWarnings = currentOptions.warnings;
       isInteractive = currentOptions.interactive;
       isMulti = currentOptions.multi;
@@ -58,6 +60,9 @@ const cli = {
       }
       if (cacheLocation) {
         configuration.cacheLocation = cacheLocation;
+      }
+      if (rulesDir) {
+        configuration.rulePaths = rulesDir;
       }
 
       nibbler.configure(configuration);

--- a/src/config/options.js
+++ b/src/config/options.js
@@ -54,6 +54,11 @@ export default optionator({
     concatRepeatedArrays: true,
     description         : 'Only show results for specified rule(s)'
   }, {
+    option              : 'rulesdir',
+    type                : '[String]',
+    concatRepeatedArrays: true,
+    description         : 'Path to custom eslint rules'
+  }, {
     option     : 'warnings',
     type       : 'Boolean',
     default    : 'true',


### PR DESCRIPTION
This adds support for the eslint `--rulesdir` option.  Nothing fancy.

https://eslint.org/docs/user-guide/command-line-interface#-rulesdir