### PR TITLE
Export and use a new function: fixNibbles()

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -4,7 +4,6 @@ const nibbler = require('./nibbler');
 const fmt = require('./config/formatters');
 const chalk = require('chalk');
 const inquirer = require('inquirer');
-const { fix } = require('eslint-filtered-fix');
 const options = require('./config/options');
 const { version } = require('../package.json');
 
@@ -180,7 +179,7 @@ const cli = {
                 rules   : isMulti ? answers.rule : [answers.rule],
                 warnings: answers.fixWarnings
               };
-              const fixedReport = await fix(files, fixOptions, configuration);
+              const fixedReport = await nibbler.fixNibbles(files, fixOptions, configuration);
               const ruleResults = nibbler.getRuleResults(fixedReport, answers.rule);
               if (ruleResults.errorCount > 0 || ruleResults.warningCount > 0) {
                 const detailed = await nibbler.getFormattedResults(ruleResults, fmt.detailed);

--- a/src/nibbler.js
+++ b/src/nibbler.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { ESLint } = require('eslint');
+const { fix } = require('eslint-filtered-fix');
 let cli = new ESLint({});
 
 function getCounts(messages) {
@@ -112,6 +113,15 @@ module.exports = {
 
   async nibbleOnFiles(files) {
     const results = await cli.lintFiles(files);
+    const report = {
+      results,
+      ...calculateStatsPerRun(results)
+    };
+    return report;
+  },
+
+  async fixNibbles(files, fixOptions, configuration) {
+    const results = await fix(files, fixOptions, configuration);
     const report = {
       results,
       ...calculateStatsPerRun(results)


### PR DESCRIPTION
Commit dfd44397 added support for ESLint 8. `nibbleOnFile()` was updated to add in the roll-up statistics, but that change missed the fact that `eslint-filtered-fix.fix()` also no longer includes the roll-up statistics.

This PR exports a new function called `fixNibbles()` which calls `fix()` and then adds in the roll-up statistics using the existing `calculateStatsPerRun()` function. The call to `fix()` could have been kept within the `cli` module, but that would have required bigger changes to copy/move/export `calculateStatsPerRun()` for use in there, so this seems like the simplest solution.

This wasn't picked up by the tests as auto-fix is only available in interactive mode, and there are no tests for interactive mode. Adding support for testing interactive mode would require investigation and more time than I have available, so there are still no tests for this. This change can be tested easily by running `eslint-nibble` interactively against a file with auto-fixable errors.

Fixes #90