### PR TITLE
Add --resolve-plugins-relative-to option

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ eslint-nibble --ext .jsx,.js lib/
 ESLint will automatically detect config files with [standard naming](http://eslint.org/docs/user-guide/configuring#configuration-file-formats).
 Add the `--config` option to specify a different config file for ESLint to use.
 
+### `--resolve-plugins-relative-to`
+
+Changes the folder where plugins are resolved from.  See the
+[ESLint docs](https://eslint.org/docs/user-guide/command-line-interface#--resolve-plugins-relative-to)
+for more details.
+
 ### `--cache`
 
 Highly recommended.  ESLint will cache the results of linting, causing subsequent runs to be much faster.  See the

--- a/src/cli.js
+++ b/src/cli.js
@@ -14,6 +14,7 @@ const cli = {
         files,
         extensions,
         configFile,
+        resolvePluginsRelativeTo,
         cache,
         cacheLocation,
         allowedRules,
@@ -30,6 +31,7 @@ const cli = {
       files = currentOptions._;
       extensions = currentOptions.ext;
       configFile = currentOptions.config;
+      resolvePluginsRelativeTo = currentOptions.resolvePluginsRelativeTo;
       cache = currentOptions.cache;
       cacheLocation = currentOptions.cacheLocation;
       allowedRules = currentOptions.rule;
@@ -55,6 +57,9 @@ const cli = {
       const configuration = { extensions };
       if (configFile) {
         configuration.overrideConfigFile = configFile;
+      }
+      if (resolvePluginsRelativeTo) {
+        configuration.resolvePluginsRelativeTo = resolvePluginsRelativeTo;
       }
       if (cache) {
         configuration.cache = cache;

--- a/src/config/options.js
+++ b/src/config/options.js
@@ -40,6 +40,10 @@ module.exports = optionator({
     type       : 'path::String',
     description: 'Use configuration from this file or shareable config'
   }, {
+    option     : 'resolve-plugins-relative-to',
+    type       : 'path::String',
+    description: 'Changes the folder where plugins are resolved from'
+  }, {
     option     : 'cache',
     type       : 'Boolean',
     default    : 'false',
@@ -82,5 +86,8 @@ module.exports = optionator({
     option     : 'fixable-only',
     type       : 'Boolean',
     description: 'Only show fixable rules in output results'
-  }]
+  }],
+  helpStyle: {
+    maxPadFactor: 2.5
+  }
 });


### PR DESCRIPTION
Closes #98.

This seems to do the trick locally. Because the option is kind of long, I had to set `maxPadFactor: 2.5` to keep the options aligned. I think it still looks okay, but it might limit the amount of descriptive text per line on a standard width terminal a bit too much.

I couldn't find any good alternatives in the optionator options, but of course we could rename the option to something shorter (at the cost of losing parity with the ESLint CLI).