### PR TITLE
Pull in pull in summary line generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,7 @@ npm run nibble
 ```
 
 Eslint-nibble will then display a rundown of the rules that are failing and a summary of the results, 
-using [eslint-stats](https://github.com/ganimomer/eslint-stats) 
-and [eslint-summary](https://github.com/davidwaterston/eslint-summary), and will ask you to pick a rule to work on:
+using [eslint-stats](https://github.com/ganimomer/eslint-stats) and will ask you to pick a rule to work on:
 
 ![eslint-stats-screenshot](docs/eslint-stats-screenshot.png)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,9 @@
         "chalk": "^4.1.1",
         "eslint-filtered-fix": "^0.3.0",
         "eslint-formatter-friendly": "^7.0.0",
-        "eslint-summary": "^1.0.0",
         "inquirer": "^8.2.3",
-        "optionator": "^0.9.1"
+        "optionator": "^0.9.1",
+        "text-table": "^0.2.0"
       },
       "bin": {
         "eslint-nibble": "bin/eslint-nibble.js"
@@ -1501,76 +1501,6 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/eslint-summary": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-summary/-/eslint-summary-1.0.0.tgz",
-      "integrity": "sha1-uBHwBDcBayDA9vUjRHm9Y5W1eIY=",
-      "dependencies": {
-        "chalk": "^1.0.0",
-        "text-table": "^0.2.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/eslint-summary/node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/eslint-summary/node_modules/ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/eslint-summary/node_modules/chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-      "dependencies": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/eslint-summary/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/eslint-summary/node_modules/strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/eslint-summary/node_modules/supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "node_modules/eslint-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
@@ -2025,25 +1955,6 @@
       },
       "engines": {
         "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/has-ansi/node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/has-bigints": {
@@ -3888,7 +3799,7 @@
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
     },
     "node_modules/through": {
       "version": "2.3.8",
@@ -5292,57 +5203,6 @@
         "estraverse": "^5.2.0"
       }
     },
-    "eslint-summary": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-summary/-/eslint-summary-1.0.0.tgz",
-      "integrity": "sha1-uBHwBDcBayDA9vUjRHm9Y5W1eIY=",
-      "requires": {
-        "chalk": "^1.0.0",
-        "text-table": "^0.2.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-        }
-      }
-    },
     "eslint-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
@@ -5644,21 +5504,6 @@
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
-      }
-    },
-    "has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "requires": {
-        "ansi-regex": "^2.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="
-        }
       }
     },
     "has-bigints": {
@@ -6993,7 +6838,7 @@
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
     },
     "through": {
       "version": "2.3.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "eslint-plugin-import": "^2.27.4",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-promise": "^6.1.1",
-        "strip-ansi": "^7.0.1",
         "tap-difflet": "^0.7.2",
         "tape": "^5.6.0",
         "tape-catch": "^1.0.6"
@@ -351,18 +350,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
     "node_modules/ansi-styles": {
@@ -3612,21 +3599,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/strip-ansi": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
-      "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
     "node_modules/strip-bom": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
@@ -4436,12 +4408,6 @@
       "requires": {
         "type-fest": "^0.21.3"
       }
-    },
-    "ansi-regex": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-      "dev": true
     },
     "ansi-styles": {
       "version": "4.3.0",
@@ -6782,15 +6748,6 @@
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
         "es-abstract": "^1.20.4"
-      }
-    },
-    "strip-ansi": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
-      "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "^6.0.1"
       }
     },
     "strip-bom": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "eslint-plugin-import": "^2.27.4",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-promise": "^6.1.1",
+        "strip-ansi": "^7.0.1",
         "tap-difflet": "^0.7.2",
         "tape": "^5.6.0",
         "tape-catch": "^1.0.6"
@@ -353,11 +354,15 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "dev": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
     "node_modules/ansi-styles": {
@@ -1533,6 +1538,14 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/eslint/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/eslint/node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -1572,6 +1585,17 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/eslint/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/espree": {
@@ -2160,6 +2184,25 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/inquirer/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inquirer/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/internal-slot": {
@@ -2903,6 +2946,25 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/ora/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ora/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
@@ -3486,6 +3548,25 @@
         "node": ">=8"
       }
     },
+    "node_modules/string-width/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/string.prototype.trim": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.6.tgz",
@@ -3532,14 +3613,18 @@
       }
     },
     "node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
+      "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
+      "dev": true,
       "dependencies": {
-        "ansi-regex": "^5.0.1"
+        "ansi-regex": "^6.0.1"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/strip-bom": {
@@ -4063,6 +4148,25 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -4334,9 +4438,10 @@
       }
     },
     "ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "dev": true
     },
     "ansi-styles": {
       "version": "4.3.0",
@@ -4873,6 +4978,11 @@
         "text-table": "^0.2.0"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+        },
         "argparse": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -4899,6 +5009,14 @@
           "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
           "requires": {
             "argparse": "^2.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "requires": {
+            "ansi-regex": "^5.0.1"
           }
         }
       }
@@ -5644,6 +5762,21 @@
         "strip-ansi": "^6.0.0",
         "through": "^2.3.6",
         "wrap-ansi": "^7.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        }
       }
     },
     "internal-slot": {
@@ -6178,6 +6311,21 @@
         "log-symbols": "^4.1.0",
         "strip-ansi": "^6.0.0",
         "wcwidth": "^1.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        }
       }
     },
     "os-tmpdir": {
@@ -6586,6 +6734,21 @@
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
         "strip-ansi": "^6.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        }
       }
     },
     "string.prototype.trim": {
@@ -6622,11 +6785,12 @@
       }
     },
     "strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
+      "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
+      "dev": true,
       "requires": {
-        "ansi-regex": "^5.0.1"
+        "ansi-regex": "^6.0.1"
       }
     },
     "strip-bom": {
@@ -7053,6 +7217,21 @@
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
         "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        }
       }
     },
     "wrappy": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "linting",
     "linter",
     "eslint-stats",
-    "eslint-summary",
     "eslint-friendly-formatter"
   ],
   "author": "Ian VanSchooten",
@@ -37,9 +36,9 @@
     "chalk": "^4.1.1",
     "eslint-filtered-fix": "^0.3.0",
     "eslint-formatter-friendly": "^7.0.0",
-    "eslint-summary": "^1.0.0",
     "inquirer": "^8.2.3",
-    "optionator": "^0.9.1"
+    "optionator": "^0.9.1",
+    "text-table": "^0.2.0"
   },
   "devDependencies": {
     "eslint": "^8.31.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "eslint-plugin-import": "^2.27.4",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^6.1.1",
-    "strip-ansi": "^7.0.1",
     "tap-difflet": "^0.7.2",
     "tape": "^5.6.0",
     "tape-catch": "^1.0.6"

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "eslint-plugin-import": "^2.27.4",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^6.1.1",
+    "strip-ansi": "^7.0.1",
     "tap-difflet": "^0.7.2",
     "tape": "^5.6.0",
     "tape-catch": "^1.0.6"

--- a/src/config/formatters.js
+++ b/src/config/formatters.js
@@ -3,7 +3,7 @@ These will be used as custom formatters.
  */
 
 const stats = require.resolve('@ianvs/eslint-stats/byErrorAndWarning.js');
-const summary = require.resolve('eslint-summary/summary.js');
+const summary = require.resolve('../summary.js');
 const detailed = require.resolve('eslint-formatter-friendly');
 
 module.exports = {

--- a/src/summary.js
+++ b/src/summary.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const chalk = require('chalk');
+const table = require('text-table');
+
+const pluralize = function (word, count) {
+  const plural = count === 1 ? word : word + 's';
+  return plural;
+};
+
+module.exports = function (results) {
+  const errorColor = 'red';
+  const warningColor = 'yellow';
+
+  let errorCount = 0;
+  let fileCount = 0;
+  let failureCount = 0;
+  let passCount = 0;
+  let warningCount = 0;
+
+  results.forEach(function (result) {
+    const messages = result.messages;
+
+    if (messages.length === 0) {
+      passCount++;
+    } else {
+      failureCount++;
+      warningCount += result.warningCount;
+      errorCount += result.errorCount;
+    }
+  });
+
+  fileCount = passCount + failureCount;
+
+  const summaryLineArray = [
+    chalk.bold(fileCount + ' ' + pluralize('file', fileCount) + ' checked.'),
+    chalk.bold(passCount + ' passed.'),
+    chalk.bold(failureCount + ' failed.')
+  ];
+
+  if (warningCount || errorCount) {
+    summaryLineArray.push(chalk[warningColor].bold(warningCount + ' ' + pluralize('warning', warningCount) + '.'));
+    summaryLineArray.push(chalk[errorColor].bold(errorCount + ' ' + pluralize('error', errorCount) + '.'));
+  }
+
+  return '\n' +
+            table([summaryLineArray]) +
+            '\n';
+};

--- a/tests/src/cli-test.js
+++ b/tests/src/cli-test.js
@@ -2,6 +2,7 @@
 
 
 var test = require('tape-catch');
+var stripAnsi = require('strip-ansi');
 var cli = require('../../src/cli');
 var path = require('path');
 
@@ -72,21 +73,21 @@ test('cli :: returns exit code without menu when --no-interactive is set', async
   t.equal(await cli.execute([nodeBin, nibbleBin, okayPath, '--no-interactive']), 0, 'exits with 0 if no problems');
   console.log = function (input) {
     console.log = origConsoleLog;
-    t.ok(input.includes('No lint failures found for rule(s): prefer-const', 'Warns user'));
+    t.ok(stripAnsi(input).includes('No lint failures found for rule(s): prefer-const', 'Warns user'));
     // Ignore second call to console.log
     mockLogOnce(origConsoleLog);
   };
   t.equal(await cli.execute([nodeBin, nibbleBin, erroringPath, '--no-interactive', '--rule', 'prefer-const']), 0, 'exits with 0 if all problems are filtered out');
   console.log = function (input) {
     console.log = origConsoleLog;
-    t.ok(input.includes('1:12  error  Missing semicolon', 'Reports semi error'));
-    t.ok(input.includes('2:1   error  Unary operator \'++\' used', 'Reports plusplus error'));
+    t.ok(stripAnsi(input).includes('1:12  error  Missing semicolon', 'Reports semi error'));
+    t.ok(stripAnsi(input).includes('2:1   error  Unary operator \'++\' used', 'Reports plusplus error'));
   };
   t.equal(await cli.execute([nodeBin, nibbleBin, multiErrorPath, '--no-interactive']), 1, 'exits with 1 if there are multiple errors');
   console.log = function (input) {
     console.log = origConsoleLog;
-    t.ok(input.includes('1:12  error  Missing semicolon', 'Reports semi error'));
-    t.ok(!input.includes('Unary operator \'++\' used'), 'Does not report plusplus error');
+    t.ok(stripAnsi(input).includes('1:12  error  Missing semicolon', 'Reports semi error'));
+    t.ok(!stripAnsi(input).includes('Unary operator \'++\' used'), 'Does not report plusplus error');
   };
   t.equal(
     await cli.execute([nodeBin, nibbleBin, multiErrorPath, '--no-interactive', '--rule', 'semi']),
@@ -113,13 +114,13 @@ test('cli :: outputs the results using a provided formatter if not interactive',
   // Assert that correct formatter is used for console output
   console.log = function (input) {
     console.log = origConsoleLog;
-    t.ok(input.includes('1:12  error  Missing semicolon  semi'), 'Default eslint formatter is used if none is specified');
+    t.ok(stripAnsi(input).includes('1:12  error  Missing semicolon  semi'), 'Default eslint formatter is used if none is specified');
   };
   await cli.execute([nodeBin, nibbleBin, erroringPath, '--no-interactive']);
   // Assert that correct formatter is used for console output
   console.log = function (input) {
     console.log = origConsoleLog;
-    t.ok(input.includes('semi-error/no-semi.js: line 1, col 12, Error - Missing semicolon. (semi)', 'Specified formatter is used'));
+    t.ok(stripAnsi(input).includes('semi-error/no-semi.js: line 1, col 12, Error - Missing semicolon. (semi)', 'Specified formatter is used'));
   };
   await cli.execute([nodeBin, nibbleBin, erroringPath, '--no-interactive', '--format', 'compact']);
 

--- a/tests/src/cli-test.js
+++ b/tests/src/cli-test.js
@@ -2,7 +2,6 @@
 
 
 var test = require('tape-catch');
-var stripAnsi = require('strip-ansi');
 var cli = require('../../src/cli');
 var path = require('path');
 
@@ -73,21 +72,21 @@ test('cli :: returns exit code without menu when --no-interactive is set', async
   t.equal(await cli.execute([nodeBin, nibbleBin, okayPath, '--no-interactive']), 0, 'exits with 0 if no problems');
   console.log = function (input) {
     console.log = origConsoleLog;
-    t.ok(stripAnsi(input).includes('No lint failures found for rule(s): prefer-const', 'Warns user'));
+    t.ok(input.includes('No lint failures found for rule(s): prefer-const', 'Warns user'));
     // Ignore second call to console.log
     mockLogOnce(origConsoleLog);
   };
   t.equal(await cli.execute([nodeBin, nibbleBin, erroringPath, '--no-interactive', '--rule', 'prefer-const']), 0, 'exits with 0 if all problems are filtered out');
   console.log = function (input) {
     console.log = origConsoleLog;
-    t.ok(stripAnsi(input).includes('1:12  error  Missing semicolon', 'Reports semi error'));
-    t.ok(stripAnsi(input).includes('2:1   error  Unary operator \'++\' used', 'Reports plusplus error'));
+    t.ok(input.includes('1:12  error  Missing semicolon', 'Reports semi error'));
+    t.ok(input.includes('2:1   error  Unary operator \'++\' used', 'Reports plusplus error'));
   };
   t.equal(await cli.execute([nodeBin, nibbleBin, multiErrorPath, '--no-interactive']), 1, 'exits with 1 if there are multiple errors');
   console.log = function (input) {
     console.log = origConsoleLog;
-    t.ok(stripAnsi(input).includes('1:12  error  Missing semicolon', 'Reports semi error'));
-    t.ok(!stripAnsi(input).includes('Unary operator \'++\' used'), 'Does not report plusplus error');
+    t.ok(input.includes('1:12  error  Missing semicolon', 'Reports semi error'));
+    t.ok(!input.includes('Unary operator \'++\' used'), 'Does not report plusplus error');
   };
   t.equal(
     await cli.execute([nodeBin, nibbleBin, multiErrorPath, '--no-interactive', '--rule', 'semi']),
@@ -114,13 +113,13 @@ test('cli :: outputs the results using a provided formatter if not interactive',
   // Assert that correct formatter is used for console output
   console.log = function (input) {
     console.log = origConsoleLog;
-    t.ok(stripAnsi(input).includes('1:12  error  Missing semicolon  semi'), 'Default eslint formatter is used if none is specified');
+    t.ok(input.includes('1:12  error  Missing semicolon  semi'), 'Default eslint formatter is used if none is specified');
   };
   await cli.execute([nodeBin, nibbleBin, erroringPath, '--no-interactive']);
   // Assert that correct formatter is used for console output
   console.log = function (input) {
     console.log = origConsoleLog;
-    t.ok(stripAnsi(input).includes('semi-error/no-semi.js: line 1, col 12, Error - Missing semicolon. (semi)', 'Specified formatter is used'));
+    t.ok(input.includes('semi-error/no-semi.js: line 1, col 12, Error - Missing semicolon. (semi)', 'Specified formatter is used'));
   };
   await cli.execute([nodeBin, nibbleBin, erroringPath, '--no-interactive', '--format', 'compact']);
 

--- a/tests/src/summary-test.js
+++ b/tests/src/summary-test.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var test = require('tape-catch');
-var stripAnsi = require('strip-ansi');
 var summary = require('../../src/summary');
 
 const aPass = { messages: '' };
@@ -12,26 +11,26 @@ test('summary :: A Pass', async function (t) {
   t.plan(2);
   const result = summary([aPass]);
   t.ok(result, 'returns summary');
-  t.equal(stripAnsi(result), '\n1 file checked.  1 passed.  0 failed.\n', 'Summary with 1 pass, 0 fail');
+  t.equal(result, '\n1 file checked.  1 passed.  0 failed.\n', 'Summary with 1 pass, 0 fail');
 });
 
 test('summary :: A Warning', async function (t) {
   t.plan(2);
   const result = summary([aWarning]);
   t.ok(result, 'returns summary');
-  t.equal(stripAnsi(result), '\n1 file checked.  0 passed.  1 failed.  1 warning.  0 errors.\n', 'Summary with 0 pass, 1 fail');
+  t.equal(result, '\n1 file checked.  0 passed.  1 failed.  1 warning.  0 errors.\n', 'Summary with 0 pass, 1 fail');
 });
 
 test('summary :: A Error', async function (t) {
   t.plan(2);
   const result = summary([aError]);
   t.ok(result, 'returns summary');
-  t.equal(stripAnsi(result), '\n1 file checked.  0 passed.  1 failed.  0 warnings.  1 error.\n', 'Summary with 0 pass, 1 fail');
+  t.equal(result, '\n1 file checked.  0 passed.  1 failed.  0 warnings.  1 error.\n', 'Summary with 0 pass, 1 fail');
 });
 
 test('summary :: A mix of Pass/Warning/Errors', async function (t) {
   t.plan(2);
   const result = summary([aPass, aPass, aWarning, aWarning, aError, aError]);
   t.ok(result, 'returns summary');
-  t.equal(stripAnsi(result), '\n6 files checked.  2 passed.  4 failed.  2 warnings.  2 errors.\n', 'Summary with 2 pass, 4 fail');
+  t.equal(result, '\n6 files checked.  2 passed.  4 failed.  2 warnings.  2 errors.\n', 'Summary with 2 pass, 4 fail');
 });

--- a/tests/src/summary-test.js
+++ b/tests/src/summary-test.js
@@ -1,0 +1,40 @@
+'use strict';
+
+var test = require('tape-catch');
+var summary = require('../../src/summary');
+
+const aPass = { messages: '' };
+const aWarning = { messages: 'A warning', warningCount: 1, errorCount: 0 };
+const aError = { messages: 'A error', warningCount: 0, errorCount: 1 };
+
+// Source: https://stackoverflow.com/a/7150870
+// eslint-disable-next-line no-control-regex
+const stripANSI = (string) => string.replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, '');
+
+test('summary :: A Pass', async function (t) {
+  t.plan(2);
+  const result = summary([aPass]);
+  t.ok(result, 'returns summary');
+  t.equal(stripANSI(result), '\n1 file checked.  1 passed.  0 failed.\n', 'Summary with 1 pass, 0 fail');
+});
+
+test('summary :: A Warning', async function (t) {
+  t.plan(2);
+  const result = summary([aWarning]);
+  t.ok(result, 'returns summary');
+  t.equal(stripANSI(result), '\n1 file checked.  0 passed.  1 failed.  1 warning.  0 errors.\n', 'Summary with 0 pass, 1 fail');
+});
+
+test('summary :: A Error', async function (t) {
+  t.plan(2);
+  const result = summary([aError]);
+  t.ok(result, 'returns summary');
+  t.equal(stripANSI(result), '\n1 file checked.  0 passed.  1 failed.  0 warnings.  1 error.\n', 'Summary with 0 pass, 1 fail');
+});
+
+test('summary :: A mix of Pass/Warning/Errors', async function (t) {
+  t.plan(2);
+  const result = summary([aPass, aPass, aWarning, aWarning, aError, aError]);
+  t.ok(result, 'returns summary');
+  t.equal(stripANSI(result), '\n6 files checked.  2 passed.  4 failed.  2 warnings.  2 errors.\n', 'Summary with 2 pass, 4 fail');
+});

--- a/tests/src/summary-test.js
+++ b/tests/src/summary-test.js
@@ -1,40 +1,37 @@
 'use strict';
 
 var test = require('tape-catch');
+var stripAnsi = require('strip-ansi');
 var summary = require('../../src/summary');
 
 const aPass = { messages: '' };
 const aWarning = { messages: 'A warning', warningCount: 1, errorCount: 0 };
 const aError = { messages: 'A error', warningCount: 0, errorCount: 1 };
 
-// Source: https://stackoverflow.com/a/7150870
-// eslint-disable-next-line no-control-regex
-const stripANSI = (string) => string.replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, '');
-
 test('summary :: A Pass', async function (t) {
   t.plan(2);
   const result = summary([aPass]);
   t.ok(result, 'returns summary');
-  t.equal(stripANSI(result), '\n1 file checked.  1 passed.  0 failed.\n', 'Summary with 1 pass, 0 fail');
+  t.equal(stripAnsi(result), '\n1 file checked.  1 passed.  0 failed.\n', 'Summary with 1 pass, 0 fail');
 });
 
 test('summary :: A Warning', async function (t) {
   t.plan(2);
   const result = summary([aWarning]);
   t.ok(result, 'returns summary');
-  t.equal(stripANSI(result), '\n1 file checked.  0 passed.  1 failed.  1 warning.  0 errors.\n', 'Summary with 0 pass, 1 fail');
+  t.equal(stripAnsi(result), '\n1 file checked.  0 passed.  1 failed.  1 warning.  0 errors.\n', 'Summary with 0 pass, 1 fail');
 });
 
 test('summary :: A Error', async function (t) {
   t.plan(2);
   const result = summary([aError]);
   t.ok(result, 'returns summary');
-  t.equal(stripANSI(result), '\n1 file checked.  0 passed.  1 failed.  0 warnings.  1 error.\n', 'Summary with 0 pass, 1 fail');
+  t.equal(stripAnsi(result), '\n1 file checked.  0 passed.  1 failed.  0 warnings.  1 error.\n', 'Summary with 0 pass, 1 fail');
 });
 
 test('summary :: A mix of Pass/Warning/Errors', async function (t) {
   t.plan(2);
   const result = summary([aPass, aPass, aWarning, aWarning, aError, aError]);
   t.ok(result, 'returns summary');
-  t.equal(stripANSI(result), '\n6 files checked.  2 passed.  4 failed.  2 warnings.  2 errors.\n', 'Summary with 2 pass, 4 fail');
+  t.equal(stripAnsi(result), '\n6 files checked.  2 passed.  4 failed.  2 warnings.  2 errors.\n', 'Summary with 2 pass, 4 fail');
 });


### PR DESCRIPTION
Fixes https://github.com/IanVS/eslint-nibble/issues/107 

# Background
[`eslint-summary`](https://github.com/davidwaterston/eslint-summary) provides the summary line for `eslint-nibble`.
![image](https://user-images.githubusercontent.com/220755/230822681-530510d9-caee-465e-b714-d5af3e9a0ae7.png)

While `eslint-nibble` has been maintained, `eslint-summary` has not for ~8yrs. For example `eslint-nibble` is using `"chalk": "^4.1.1"` while `eslint-summary` is still on  "chalk": "^1.0.0".

The functionality of `eslint-summary` is rather [straightforward](https://github.com/davidwaterston/eslint-summary/blob/master/summary.js). Does it make sense to adopt and pull this code into `eslint-nibble`?

This came to my attention when looking through my repos dependencies and vulnerabilities and chasing down where older versions of `chalk` where coming from.

## See also
Issue https://github.com/IanVS/eslint-nibble/issues/107 Discussion
