### PR TITLE
Change default extensions option to run on all file types

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -54,7 +54,10 @@ const cli = {
       // Show help
       console.log(options.generateHelp());
     } else {
-      const configuration = { extensions };
+      const configuration = { };
+      if (extensions) {
+        configuration.extensions = extensions;
+      }
       if (configFile) {
         configuration.overrideConfigFile = configFile;
       }

--- a/src/config/options.js
+++ b/src/config/options.js
@@ -32,7 +32,7 @@ module.exports = optionator({
   }, {
     option     : 'ext',
     type       : '[String]',
-    default    : '.js',
+    default    : '',
     description: 'Specify JavaScript file extensions'
   }, {
     option     : 'config',


### PR DESCRIPTION
I spent a lot of time thinking I had very few errors, until I found out that eslint-nibble does not run on my typescript files 😢 

Making the extensions list empty by default means that the default behavior will be to run on all files.