### PR TITLE
Fix page size

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -153,12 +153,12 @@ const cli = {
             await inquirer.checkbox({
               message: 'Which rule(s) would you like to view?',
               choices: results,
-              pageSize: results.length,
+              pageSize: process.stdout.rows - 5,
             })
           : await inquirer.select({
               message: 'Which rule would you like to view?',
               choices: results,
-              pageSize: results.length,
+              pageSize: process.stdout.rows - 5,
             });
 
         const ruleReport = nibbler.getRuleResults(report, ruleAnswer);


### PR DESCRIPTION
Fixes: https://github.com/IanVS/eslint-nibble/issues/110

The issue is that we were setting the page size to the total list length. The problem is that paging is supposed to allow for lists longer than some window to be reliably represented. inquirer's [default page size is 7](https://github.com/SBoudrias/Inquirer.js/tree/main/packages/select#options), which we certainly want more than, but our maximum should be the total number or rows the window can support -- minus anything else we want to be in the screen. It seems that we have 5 rows of other information (a spacer line, summary, spacer line, header, then at the bottom of the pager, there is a helper line). It would seem that the math to measure this max size would be `process.stdout.rows - 5` which I have submitted as a PR.

